### PR TITLE
Basic generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+composer.lock
+vendor

--- a/A5sysTypeScriptGeneratorBundle.php
+++ b/A5sysTypeScriptGeneratorBundle.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace A5sys\TypeScriptGeneratorBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class A5sysTypeScriptGeneratorBundle extends Bundle
+{
+
+}

--- a/Command/GenerateTypeScriptCommand.php
+++ b/Command/GenerateTypeScriptCommand.php
@@ -38,6 +38,7 @@ class GenerateTypeScriptCommand extends Command
             ->setName('a5sys:ts-generator:'.$this->commandName)
             ->addArgument('input', InputArgument::REQUIRED, 'Input path')
             ->addArgument('output', InputArgument::REQUIRED, 'Output path')
+            ->setDescription(sprintf('Generate TypeScript %s from PHP classes', $this->commandName));
         ;
     }
 

--- a/Command/GenerateTypeScriptCommand.php
+++ b/Command/GenerateTypeScriptCommand.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace A5sys\TypeScriptGeneratorBundle\Command;
+
+use A5sys\TypeScriptGeneratorBundle\Generator\TypeScriptGenerator;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Class GenerateTypeScriptCommand
+ */
+class GenerateTypeScriptCommand extends Command
+{
+    private $generator;
+    private $commandName;
+
+    /**
+     * GenerateTypeScriptCommand constructor.
+     * @param \A5sys\TypeScriptGeneratorBundle\Generator\TypeScriptGenerator $generator
+     * @param string                                                         $commandName
+     * @param null                                                           $name
+     */
+    public function __construct(TypeScriptGenerator $generator, string $commandName, $name = null)
+    {
+        $this->generator = $generator;
+        $this->commandName = $commandName;
+        parent::__construct($name);
+    }
+
+    /**
+     * @{@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('a5sys:ts-generator:'.$this->commandName)
+            ->addArgument('input', InputArgument::REQUIRED, 'Input path')
+            ->addArgument('output', InputArgument::REQUIRED, 'Output path')
+        ;
+    }
+
+    /**
+     * @{@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $inputPath = $input->getArgument('input');
+        $outputPath = $input->getArgument('output');
+        $this->generator->generate($inputPath, $outputPath);
+    }
+}

--- a/Command/GenerateTypeScriptCommand.php
+++ b/Command/GenerateTypeScriptCommand.php
@@ -38,7 +38,7 @@ class GenerateTypeScriptCommand extends Command
             ->setName('a5sys:ts-generator:'.$this->commandName)
             ->addArgument('input', InputArgument::REQUIRED, 'Input path')
             ->addArgument('output', InputArgument::REQUIRED, 'Output path')
-            ->setDescription(sprintf('Generate TypeScript %s from PHP classes', $this->commandName));
+            ->setDescription(sprintf('Generate TypeScript %s from PHP classes', $this->commandName))
         ;
     }
 

--- a/DependencyInjection/A5sysTypeScriptGeneratorExtension.php
+++ b/DependencyInjection/A5sysTypeScriptGeneratorExtension.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace A5sys\TypeScriptGeneratorBundle\DependencyInjection;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+
+/**
+ * Class A5sysTypeScriptGeneratorExtension
+ */
+class A5sysTypeScriptGeneratorExtension extends Extension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('services.xml');
+    }
+}

--- a/Generator/TypeScriptGenerator.php
+++ b/Generator/TypeScriptGenerator.php
@@ -153,7 +153,7 @@ class TypeScriptGenerator
     private function computeArrayType(Type $type): array
     {
         if ($type->getCollectionValueType() !== null) {
-            list($inferredType, $typeToImport) = $this->getType([$type->getCollectionValueType()]);
+            [$inferredType, $typeToImport] = $this->getType([$type->getCollectionValueType()]);
 
             return [$inferredType.'[]', $typeToImport];
         }

--- a/Generator/TypeScriptGenerator.php
+++ b/Generator/TypeScriptGenerator.php
@@ -3,12 +3,8 @@
 namespace A5sys\TypeScriptGeneratorBundle\Generator;
 
 use A5sys\TypeScriptGeneratorBundle\Util\ClassExtractor;
-use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\ORM\Tools\DisconnectedClassMetadataFactory;
-use Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor;
+use Doctrine\Common\Collections\Collection;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
-use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
 use Symfony\Component\PropertyInfo\Type;
 
@@ -30,24 +26,15 @@ class TypeScriptGenerator
 
     /**
      * TypeScriptInterfaceGenerator constructor.
-     * @param \Twig_Environment $twig
-     * @param string            $templateName
+     * @param \Twig_Environment                                     $twig
+     * @param \Symfony\Component\PropertyInfo\PropertyInfoExtractor $propertyInfo
+     * @param string                                                $templateName
      */
-    public function __construct(\Twig_Environment $twig, string $templateName)
+    public function __construct(\Twig_Environment $twig, PropertyInfoExtractor $propertyInfo, string $templateName)
     {
         $this->twig = $twig;
         $this->templateName = $templateName;
-
-        $phpDocExtractor = new PhpDocExtractor();
-        $reflectionExtractor = new ReflectionExtractor();
-        $doctrineExtractor = new DoctrineExtractor(new DisconnectedClassMetadataFactory());
-
-        $this->propertyInfo = new PropertyInfoExtractor(
-            [$reflectionExtractor, $doctrineExtractor],
-            [$phpDocExtractor, $reflectionExtractor, $doctrineExtractor],
-            [$phpDocExtractor],
-            [$reflectionExtractor]
-        );
+        $this->propertyInfo = $propertyInfo;
     }
 
     /**
@@ -122,9 +109,10 @@ class TypeScriptGenerator
                     return $this->computePritimiveType($type);
 
                 case Type::BUILTIN_TYPE_ARRAY:
+                case Type::BUILTIN_TYPE_OBJECT && ($type->getClassName() === Collection::class):
                     return $this->computeArrayType($type);
 
-                case Type::BUILTIN_TYPE_OBJECT && ($type->getClassName() !== ArrayCollection::class):
+                case Type::BUILTIN_TYPE_OBJECT && ($type->getClassName() !== Collection::class):
                     return $this->computeObjectType($type);
             }
         }

--- a/Generator/TypeScriptGenerator.php
+++ b/Generator/TypeScriptGenerator.php
@@ -14,7 +14,6 @@ use Symfony\Component\PropertyInfo\Type;
 
 /**
  * Class TypeScriptGenerator
- * @package A5sys\TypeScriptGeneratorBundle\Generator
  */
 class TypeScriptGenerator
 {

--- a/Generator/TypeScriptGenerator.php
+++ b/Generator/TypeScriptGenerator.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace A5sys\TypeScriptGeneratorBundle\Generator;
+
+use A5sys\TypeScriptGeneratorBundle\Util\ClassExtractor;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\Tools\DisconnectedClassMetadataFactory;
+use Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
+use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * Class TypeScriptGenerator
+ * @package A5sys\TypeScriptGeneratorBundle\Generator
+ */
+class TypeScriptGenerator
+{
+    private const TYPE_TRANSLATION = [
+        'DateTime' => 'Date',
+        'int' => 'number',
+        'float' => 'number',
+        'bool' => 'boolean',
+    ];
+
+    private $twig;
+    private $templateName;
+    private $propertyInfo;
+
+    /**
+     * TypeScriptInterfaceGenerator constructor.
+     * @param \Twig_Environment $twig
+     * @param string            $templateName
+     */
+    public function __construct(\Twig_Environment $twig, string $templateName)
+    {
+        $this->twig = $twig;
+        $this->templateName = $templateName;
+
+        $phpDocExtractor = new PhpDocExtractor();
+        $reflectionExtractor = new ReflectionExtractor();
+        $doctrineExtractor = new DoctrineExtractor(new DisconnectedClassMetadataFactory());
+
+        $this->propertyInfo = new PropertyInfoExtractor(
+            [$reflectionExtractor, $doctrineExtractor],
+            [$phpDocExtractor, $reflectionExtractor, $doctrineExtractor],
+            [$phpDocExtractor],
+            [$reflectionExtractor]
+        );
+    }
+
+    /**
+     * @param string $inputPath
+     * @param string $outputPath
+     */
+    public function generate(string $inputPath, string $outputPath): void
+    {
+        $this->checkPath($inputPath);
+        $this->checkPath($outputPath);
+
+        $template = $this->twig->load($this->templateName);
+        $fs = new Filesystem();
+
+        $classes = ClassExtractor::createMap($inputPath);
+        foreach ($classes as $class) {
+            $fs->dumpFile($outputPath.'/'.$class['className'].'.ts', $template->render($this->getClassDefinition($class)));
+        }
+    }
+
+    /**
+     * @param string $path
+     * @throws \RuntimeException
+     */
+    private function checkPath(string $path): void
+    {
+        if (!is_dir($path)) {
+            throw new \InvalidArgumentException(sprintf('The provided path %s is not a directory', $path));
+        }
+    }
+
+    /**
+     * @param array $class
+     * @return array
+     */
+    private function getClassDefinition(array $class): array
+    {
+        $classDefinition = [
+            'name' => $class['className'],
+            'properties' => [],
+            'classesToImport' => [],
+        ];
+        foreach ($this->propertyInfo->getProperties($class['fqcn']) as $propertyName) {
+            $types = $this->propertyInfo->getTypes($class['fqcn'], $propertyName);
+
+            [$type, $classToImport] = $this->getType($types ?? []);
+            if ($classToImport) {
+                $classDefinition['classesToImport'][] = $classToImport;
+            }
+            $classDefinition['properties'][] = [
+                'name' => $propertyName,
+                'type' => $type,
+            ];
+        }
+
+        return $classDefinition;
+    }
+
+    /**
+     * @param \Symfony\Component\PropertyInfo\Type[] $types
+     * @return array
+     */
+    private function getType(array $types): array
+    {
+        foreach ($types as $type) {
+            switch ($type->getBuiltinType()) {
+                case Type::BUILTIN_TYPE_BOOL:
+                case Type::BUILTIN_TYPE_FLOAT:
+                case Type::BUILTIN_TYPE_INT:
+                case Type::BUILTIN_TYPE_NULL:
+                case Type::BUILTIN_TYPE_STRING:
+                    return $this->computePritimiveType($type);
+
+                case Type::BUILTIN_TYPE_ARRAY:
+                    return $this->computeArrayType($type);
+
+                case Type::BUILTIN_TYPE_OBJECT && ($type->getClassName() !== ArrayCollection::class):
+                    return $this->computeObjectType($type);
+            }
+        }
+
+        return ['any', null];
+    }
+
+    /**
+     * @param \Symfony\Component\PropertyInfo\Type $type
+     * @return array
+     */
+    private function computePritimiveType(Type $type): array
+    {
+        $returnType = $this->translateTypeName($type->getBuiltinType());
+        if ($type->isNullable()) {
+            $returnType .= ' | null';
+        }
+
+        return [$returnType, null];
+    }
+
+    /**
+     * @param \Symfony\Component\PropertyInfo\Type $type
+     * @return array
+     */
+    private function computeArrayType(Type $type): array
+    {
+        if ($type->getCollectionValueType() !== null) {
+            list($inferredType, $typeToImport) = $this->getType([$type->getCollectionValueType()]);
+
+            return [$inferredType.'[]', $typeToImport];
+        }
+
+        return ['[]', null];
+    }
+
+    /**
+     * @param \Symfony\Component\PropertyInfo\Type $type
+     * @return array
+     */
+    private function computeObjectType(Type $type): array
+    {
+        $className = (new \ReflectionClass($type->getClassName()))->getShortName();
+        $returnType = $this->translateTypeName($className);
+        if ($type->isNullable()) {
+            $returnType .= ' | null';
+        }
+
+        $typeToImport = null;
+        if ($type->getClassName() !== \DateTime::class) {
+            $typeToImport = $className;
+        }
+
+        return [$returnType, $typeToImport];
+    }
+
+    /**
+     * @param string $typeName
+     * @return string
+     */
+    private function translateTypeName(string $typeName): string
+    {
+        if (isset(static::TYPE_TRANSLATION[$typeName])) {
+            return static::TYPE_TRANSLATION[$typeName];
+        }
+
+        return $typeName;
+    }
+}

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 A5sys
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
 # TypeScriptGeneratorBundle
-Generate TypeScript Classes or Interfaces from PHP classes (phpdoc, doctrine, php types)
+This bundle adds two Symfony command to generate TypeScript classesor interfaces from PHP classes.
+
+The fields and their types are extracted from the phpdoc, Doctrine's metadata and PHP's types using [Symfony's Property Info Component](https://symfony.com/doc/current/components/property_info.html) .
+
+## Installation
+Require the bundle in Composer:
+```
+composer require --dev a5sys/typescript-generator-bundle
+```
+Register the bundle in your AppKernel:
+```php
+public function registerBundles()
+{
+    // ...
+    if ('dev' === $this->getEnvironment()) {
+        // ...
+        $bundles[] = new A5sys\TypeScriptGeneratorBundle\A5sysTypeScriptGeneratorBundle();
+    }
+}
+```
+## Usage
+To generate classes:
+```
+mkdir generated-classes
+php bin/console a5sys:ts-generator:class src/AppBundle/Entity generated-classes
+```
+This command will scan all classes in the directory `src/AppBundle/Entity` and generate their typescript's equivalence in the directory `generated-classes`.
+
+To generate interfaces:
+```
+mkdir generated-interfaces
+php bin/console a5sys:ts-generator:interface src/AppBundle/Entity generated-interfaces
+```
+This command will scan all classes in the directory `src/AppBundle/Entity` and generate their typescript's equivalence in the directory `generated-interface`.

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -17,6 +17,7 @@
         </service>
         <service id="a5sys_typescript_generator.generator" class="A5sys\TypeScriptGeneratorBundle\Generator\TypeScriptGenerator" abstract="true" lazy="true">
             <argument type="service" id="twig" />
+            <argument type="service" id="property_info" />
         </service>
         <service id="a5sys_typescript_generator.interface_generator" class="A5sys\TypeScriptGeneratorBundle\Generator\TypeScriptGenerator" parent="a5sys_typescript_generator.generator">
             <argument type="string">@A5sysTypeScriptGenerator/interface.ts.twig</argument>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="a5sys_typescript_generator.generate_interface_command" class="A5sys\TypeScriptGeneratorBundle\Command\GenerateTypeScriptCommand">
+            <argument type="service" id="a5sys_typescript_generator.interface_generator"/>
+            <argument type="string">interface</argument>
+            <tag name="console.command" />
+        </service>
+        <service id="a5sys_typescript_generator.generate_class_command" class="A5sys\TypeScriptGeneratorBundle\Command\GenerateTypeScriptCommand">
+            <argument type="service" id="a5sys_typescript_generator.class_generator"/>
+            <argument type="string">class</argument>
+            <tag name="console.command" />
+        </service>
+        <service id="a5sys_typescript_generator.generator" class="A5sys\TypeScriptGeneratorBundle\Generator\TypeScriptGenerator" abstract="true" lazy="true">
+            <argument type="service" id="twig" />
+        </service>
+        <service id="a5sys_typescript_generator.interface_generator" class="A5sys\TypeScriptGeneratorBundle\Generator\TypeScriptGenerator" parent="a5sys_typescript_generator.generator">
+            <argument type="string">@A5sysTypeScriptGenerator/interface.ts.twig</argument>
+        </service>
+        <service id="a5sys_typescript_generator.class_generator" class="A5sys\TypeScriptGeneratorBundle\Generator\TypeScriptGenerator" parent="a5sys_typescript_generator.generator">
+            <argument type="string">@A5sysTypeScriptGenerator/class.ts.twig</argument>
+        </service>
+    </services>
+</container>

--- a/Resources/views/class.ts.twig
+++ b/Resources/views/class.ts.twig
@@ -1,0 +1,11 @@
+{% for classToImport in classesToImport %}
+import { {{ classToImport }} } from './{{ classToImport }}';
+{% endfor %}
+
+export class {{ name }} {
+  constructor(
+  {% for property in properties %}
+  {{ property.name }}: {{ property.type }},
+  {% endfor -%}
+  ) {}
+}

--- a/Resources/views/interface.ts.twig
+++ b/Resources/views/interface.ts.twig
@@ -1,0 +1,9 @@
+{% for classToImport in classesToImport %}
+import { {{ classToImport }} } from './{{ classToImport }}';
+{% endfor %}
+
+export interface {{ name }} {
+{% for property in properties %}
+  {{ property.name }}: {{ property.type }};
+{% endfor %}
+}

--- a/Util/ClassExtractor.php
+++ b/Util/ClassExtractor.php
@@ -36,10 +36,8 @@ class ClassExtractor
 
             $classes = static::findClasses($path);
 
-            if (\PHP_VERSION_ID >= 70000) {
-                // PHP 7 memory manager will not release after token_get_all(), see https://bugs.php.net/70098
-                gc_mem_caches();
-            }
+            // PHP 7 memory manager will not release after token_get_all(), see https://bugs.php.net/70098
+            gc_mem_caches();
 
             $map = array_merge($map, $classes);
         }

--- a/Util/ClassExtractor.php
+++ b/Util/ClassExtractor.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace A5sys\TypeScriptGeneratorBundle\Util;
+
+/**
+ * Copied from by Symfony's ClassMapGenerator which is now deprecated
+ * https://github.com/symfony/class-loader/blob/3.3/ClassMapGenerator.php
+ */
+class ClassExtractor
+{
+    /**
+     * Iterate over all files in the given directory searching for classes.
+     *
+     * @param \Iterator|string $dir The directory to search in or an iterator
+     *
+     * @return array A class map array
+     */
+    public static function createMap($dir): array
+    {
+        if (is_string($dir)) {
+            $dir = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($dir));
+        }
+
+        $map = array();
+
+        foreach ($dir as $file) {
+            if (!$file->isFile()) {
+                continue;
+            }
+
+            $path = $file->getRealPath() ?: $file->getPathname();
+
+            if ('php' !== pathinfo($path, PATHINFO_EXTENSION)) {
+                continue;
+            }
+
+            $classes = static::findClasses($path);
+
+            if (\PHP_VERSION_ID >= 70000) {
+                // PHP 7 memory manager will not release after token_get_all(), see https://bugs.php.net/70098
+                gc_mem_caches();
+            }
+
+            $map = array_merge($map, $classes);
+        }
+
+        return $map;
+    }
+
+    /**
+     * Extract the classes in the given file.
+     *
+     * @param string $path The file to check
+     *
+     * @return array The found classes
+     */
+    private static function findClasses($path): array
+    {
+        $contents = file_get_contents($path);
+        $tokens = token_get_all($contents);
+
+        $classes = array();
+
+        $namespace = '';
+        for ($i = 0; isset($tokens[$i]); ++$i) {
+            $token = $tokens[$i];
+
+            if (!isset($token[1])) {
+                continue;
+            }
+
+            $class = '';
+
+            switch ($token[0]) {
+                case T_NAMESPACE:
+                    $namespace = '';
+                    // If there is a namespace, extract it
+                    while (isset($tokens[++$i][1])) {
+                        if (in_array($tokens[$i][0], array(T_STRING, T_NS_SEPARATOR))) {
+                            $namespace .= $tokens[$i][1];
+                        }
+                    }
+                    $namespace .= '\\';
+                    break;
+                case T_CLASS:
+                case T_INTERFACE:
+                    // Skip usage of ::class constant
+                    $isClassConstant = false;
+                    for ($j = $i - 1; $j > 0; --$j) {
+                        if (!isset($tokens[$j][1])) {
+                            break;
+                        }
+
+                        if (T_DOUBLE_COLON === $tokens[$j][0]) {
+                            $isClassConstant = true;
+                            break;
+                        }
+
+                        if (!in_array($tokens[$j][0], array(T_WHITESPACE, T_DOC_COMMENT, T_COMMENT))) {
+                            break;
+                        }
+                    }
+
+                    if ($isClassConstant) {
+                        break;
+                    }
+
+                    // Find the classname
+                    while (isset($tokens[++$i][1])) {
+                        $t = $tokens[$i];
+                        if (T_STRING === $t[0]) {
+                            $class .= $t[1];
+                        } elseif ('' !== $class && T_WHITESPACE === $t[0]) {
+                            break;
+                        }
+                    }
+
+                    $classes[] = [
+                        'className' => $class,
+                        'fqcn' => ltrim($namespace.$class, '\\'),
+                    ];
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        return $classes;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,12 @@
         "php": ">= 7.1",
         "symfony/framework-bundle": "^2.8||^3.0",
         "symfony/console": "^2.8||^3.0",
-        "doctrine/doctrine-bundle": "^1.6.3",
-        "doctrine/orm": "~2.3",
         "symfony/property-info": "^2.8||^3.0",
-        "phpdocumentor/reflection-docblock": "^3.0||^4.0",
         "twig/twig": "^1.28||^2.0",
         "symfony/twig-bundle": "^2.7||^3.0"
+    },
+    "suggest": {
+        "symfony/doctrine-bridge": "Needed to extract class metadata from Doctrine",
+        "phpocumentor/reflection": "Needed to extract data from the PhpDoc"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,20 @@
+{
+    "name": "a5sys/typescript-generator-bundle",
+    "license": "MIT",
+    "autoload": {
+        "psr-4": {
+            "A5sys\\TypeScriptGeneratorBundle\\": ""
+        }
+    },
+    "require": {
+        "php": ">= 7.1",
+        "symfony/framework-bundle": "^2.8||^3.0",
+        "symfony/console": "^2.8||^3.0",
+        "doctrine/doctrine-bundle": "^1.6.3",
+        "doctrine/orm": "~2.3",
+        "symfony/property-info": "^2.8||^3.0",
+        "phpdocumentor/reflection-docblock": "^3.0||^4.0",
+        "twig/twig": "^1.28||^2.0",
+        "symfony/twig-bundle": "^2.7||^3.0"
+    }
+}


### PR DESCRIPTION
Voici ma première version pour le générateur de code TypeScript à partir de classes PHP.

L'analyse des classes se base sur le composant [Property Info](https://symfony.com/doc/current/components/property_info.html) de Symfony qui lui utilise la PHPdoc, les métadonnées Doctrine et le typage PHP pour déduire les informations sur les propriétés d'une classe.

Cette première version gère normalement les cas d'usages "basique" (je l'ai testé sur un petit projet) et il va falloir le tester sur un nombre plus conséquent d'entité pour trouver les cas limites et les corriger.

Il y a deux générateurs disponibles, un générateur d'interface ou de classes (les deux options semblent être utilisées dans le monde TypeScript, à confirmer). Les deux formats sont gérés par la même classe (et la même commande), la distinction se fait au niveau des services déclarés (je déclare plusieurs services à partir de la même classe).